### PR TITLE
SHOTS: Compatibility fixes for AC3.5+

### DIFF
--- a/buttonManager.py
+++ b/buttonManager.py
@@ -3,6 +3,17 @@
 # It also handles all communication to Artoo
 #
 
+# ************************************************************
+# *                                                          *
+# *  Solo Pixhawk 2.1 Green Cube and ArduCopter 3.5 Upgrade  *
+# *                                                          *
+# ************************************************************
+# Updated July 29, 2017 by Matt Lawrence to be compatible with 
+# the Pixhawk 2.1 Green Cube and ArduCopter 3.5+
+#  - Changed home button press from returnHome.py smart shot to ArduCopter RTL mode
+#
+
+
 import errno
 import os
 import platform
@@ -264,7 +275,7 @@ class buttonManager():
             if self.shotMgr.currentShot == shots.APP_SHOT_RTL:
                 self.shotMgr.curController.handleButton(button, event)
             elif event == btn_msg.Press:
-                self.shotMgr.enterShot(shots.APP_SHOT_RTL)
+		self.shotMgr.vehicle.mode = VehicleMode("RTL") #Places Pixhawk into ArduCopter RTL mode
 
         if button == btn_msg.ButtonCameraClick and event == btn_msg.Press:
             self.shotMgr.goproManager.handleRecordCommand(self.shotMgr.goproManager.captureMode, RECORD_COMMAND_TOGGLE)

--- a/pano.py
+++ b/pano.py
@@ -6,18 +6,27 @@
 #  Runs as a DroneKit-Python script under MAVProxy.
 #
 #  Created by Jason Short and Will Silva on 11/30/2015.
-#  Copyright (c) 2015 3D Robotics.
+#  Copyright (c) 2016 3D Robotics.
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
 #  http://www.apache.org/licenses/LICENSE-2.0
-#
+
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# ************************************************************
+# *                                                          *
+# *  Solo Pixhawk 2.1 Green Cube and ArduCopter 3.5 Upgrade  *
+# *                                                          *
+# ************************************************************
+#
+# Updated July 29, 2017 by Matt Lawrence to be compatible with the Pixhawk 2.1 Green Cube and ArduCopter 3.5+
+# - Added use of MAV_CMD_CONDITION_YAW to control copter yaw during smart shots since MSG_MOUNT_CONTROL seems to be broken in ArduCopter 3.5
+#
 
 from dronekit import Vehicle, LocationGlobalRelative, VehicleMode
 
@@ -469,27 +478,41 @@ class PanoShot():
         # if we do have a gimbal, use mount_control to set pitch and yaw
         if self.vehicle.mount_status[0] is not None:
             msg = self.vehicle.message_factory.mount_control_encode(
-                        0, 1,    # target system, target component
-                        # pitch is in centidegrees
-                        self.camPitch * 100,
-                        0.0, # roll
-                        # yaw is in centidegrees
-                        self.camYaw * 100,
-                        0 # save position
-                        )
+                    0, 1,    # target system, target component
+                    # pitch is in centidegrees
+                    self.camPitch * 100,
+                    0.0, # roll
+                    # yaw is in centidegrees
+                    0, # self.camYaw * 100, (Disabled by Matt for now due to ArduCopter master mount_control bug. Using condition_yaw instead)
+                    0 # save position
+            )
+            self.vehicle.send_mavlink(msg)
+            
+            msg = self.vehicle.message_factory.command_long_encode( # Using condition_yaw temporarily until mount_control yaw issue is fixed
+                    0, 0,    # target system, target component
+                    mavutil.mavlink.MAV_CMD_CONDITION_YAW, #command
+                    0, #confirmation
+                    self.camYaw,  # param 1 - target angle
+                    YAW_SPEED, # param 2 - yaw speed
+                    self.camDir, # param 3 - direction
+                    0.0, # relative offset
+                    0, 0, 0 # params 5-7 (unused)
+            )
+            self.vehicle.send_mavlink(msg)
+                        
         else:
             # if we don't have a gimbal, just set CONDITION_YAW
             msg = self.vehicle.message_factory.command_long_encode(
-                        0, 0,    # target system, target component
-                        mavutil.mavlink.MAV_CMD_CONDITION_YAW, #command
-                        0, #confirmation
-                        self.camYaw,  # param 1 - target angle
-                        YAW_SPEED, # param 2 - yaw speed
-                        self.camDir, # param 3 - direction
-                        0.0, # relative offset
-                        0, 0, 0 # params 5-7 (unused)
-                        )
-        self.vehicle.send_mavlink(msg)
+                    0, 0,    # target system, target component
+                    mavutil.mavlink.MAV_CMD_CONDITION_YAW, #command
+                    0, #confirmation
+                    self.camYaw,  # param 1 - target angle
+                    YAW_SPEED, # param 2 - yaw speed
+                    self.camDir, # param 3 - direction
+                    0.0, # relative offset
+                    0, 0, 0 # params 5-7 (unused)
+            )
+            self.vehicle.send_mavlink(msg)
 
     def enterPhotoMode(self):
         # switch into photo mode if we aren't already in it

--- a/rcManager.py
+++ b/rcManager.py
@@ -15,6 +15,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# ************************************************************
+# *                                                          *
+# *  Solo Pixhawk 2.1 Green Cube and ArduCopter 3.5 Upgrade  *
+# *                                                          *
+# ************************************************************
+# Updated July 29, 2017 by Matt Lawrence to be compatible with 
+# the Pixhawk 2.1 Green Cube and ArduCopter 3.5+
+# - Changed radio failsafe output on CH3 from DEFAULT_RC_MID to THROTTLE_FAILSAFE.
+#   Puts Pixhawk into Radio Failsafe rather than relying on IMX or smart shots
+#
+
+
 import os
 import socket
 import sys
@@ -132,7 +144,7 @@ class rcManager():
     def remap(self):
         if self.failsafe or self.channels == None:
             # send default values to the Pixhawk
-            self.channels = [DEFAULT_RC_MID, DEFAULT_RC_MID, DEFAULT_RC_MID, DEFAULT_RC_MID, DEFAULT_RC_MIN, CHANNEL6_MAX, DEFAULT_RC_MIN, CHANNEL8_MID ]
+            self.channels = [DEFAULT_RC_MID, DEFAULT_RC_MID, THROTTLE_FAILSAFE, DEFAULT_RC_MID, DEFAULT_RC_MIN, CHANNEL6_MAX, DEFAULT_RC_MIN, CHANNEL8_MID ]
 
         normChannels = [0]*8
 

--- a/rewind.py
+++ b/rewind.py
@@ -19,6 +19,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+
+# ************************************************************
+# *                                                          *
+# *  Solo Pixhawk 2.1 Green Cube and ArduCopter 3.5 Upgrade  *
+# *                                                          *
+# ************************************************************
+# Updated July 29, 2017 by Matt Lawrence to be compatible with
+# the Pixhawk 2.1 Green Cube and ArduCopter 3.5+
+# - When exiting rewind, use ArduCopter RTL instead of returnHome.py smart shot
+#
+
+
+
+
 from dronekit import Vehicle, LocationGlobalRelative, VehicleMode
 from pymavlink import mavutil
 import os
@@ -149,7 +163,7 @@ class RewindShot():
 
     def exitRewind(self):
         self.rewindManager.resetSpline()
-        self.shotmgr.enterShot(shots.APP_SHOT_RTL)
+        self.vehicle.mode = VehicleMode("RTL")
 
         
     def travel(self):


### PR DESCRIPTION
Two things needed to be changed with smart shots for compatibility with ArduCopter 3.5+

* Disable using the return home smart shot. Without the slew rate throttle handicapping, this performed badly and actually became hazardous. It also introduced a significant point of failure for something that is supposed to be a failsafe. Since 3DR stopped development before the return home smart shot grew into something more, it wasn't doing anything different than ArduCopter RTL mode anyway.  As such, I removed everything that used to call the return home smart shot and replaced them with ArduCopter RTL mode.

* They yaw component is not working in MSG_MOUNT_CONTROL and MAV_CMD_DO_MOUNT_CONTROL.  This is what the smart shots use for copter yaw, along with the gimbal pitch component. Since nobody could figure out what it wasn't working, I added a CONDITION_YAW command to handle the yaw. Full functionality was restored to the smart shots with this.  It is unknown if the problem is in dronekit or ArduPilot.