### PR TITLE
MODES: Add newer ArduCopter flight modes

### DIFF
--- a/extSettings.conf
+++ b/extSettings.conf
@@ -64,6 +64,10 @@ APP_SHOT_RTL = 10
 15 = Auto-tune
 16 = Position Hold
 17 = Brake
+18 = Throw (ArduCopter 3.5+)
+19 = ADS-B Avoid (ArduCopter 3.5+ and not a user mode)
+20 = Guided No GPS (ArduCopter 3.5+)
+21 = SmartRTL (ArduCopter 3.6+ Only)
 
 
 [USAGE-FUNCTIONS]

--- a/modes.py
+++ b/modes.py
@@ -21,6 +21,10 @@ MODE_NAMES = {
     15 : 'Auto-tune\0',
     16 : 'Position Hold\0',
     17 : 'Brake\0',
+    18 : 'Throw\0',
+    19 : 'ADS-B AVOID\0',
+    20 : 'GUIDED NO GPS\0',
+    21 : 'SMART RTL\0', 
     }
 
 # DroneKit uses APM's mode names.  Here is a helper function to


### PR DESCRIPTION
Several new flight modes were added to ArduCopter since the Solo was created. This patch adds support for the following new copter flight modes;
- Throw mode
- ADS-B Avoidance (not a user mode)
- Guided w/ no GPS
- Smart RTL